### PR TITLE
Support for moving the clock forward

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,8 +102,13 @@ function updateLock(file, options) {
 
             // Verify if we are within the stale threshold
             if (lock.lastUpdate <= Date.now() - options.stale) {
-                return compromisedLock(file, lock, errcode(lock.updateError || 'Unable to update lock within the stale threshold', 'ECOMPROMISED'));
+             && lock.lastUpdate > Date.now() - options.stale * 2) {
+                return compromisedLock(file, lock, 
+                    errcode(lock.updateError || 'Unable to update lock within the stale threshold', 'ECOMPROMISED'));
             }
+
+            // If the file is older than (stale * 2), we assume the clock is moved manually,
+            // which we consider a valid case
 
             // If it failed to update the lockfile, keep trying unless
             // the lockfile was deleted!

--- a/index.js
+++ b/index.js
@@ -101,7 +101,7 @@ function updateLock(file, options) {
             }
 
             // Verify if we are within the stale threshold
-            if (lock.lastUpdate <= Date.now() - options.stale) {
+            if (lock.lastUpdate <= Date.now() - options.stale
              && lock.lastUpdate > Date.now() - options.stale * 2) {
                 return compromisedLock(file, lock, 
                     errcode(lock.updateError || 'Unable to update lock within the stale threshold', 'ECOMPROMISED'));


### PR DESCRIPTION
This change handles the case where the user of the computer moves the clock forward for some reason. In the original version since the modified time of the file became too far back in the past (according to the new clock time), it was considered compromised.
Now the file is considered compromised only if it's last update is in the interval `(Now - stale* 2, Now - stale]`.
Any ideas how to better handle this case are welcome.