### PR TITLE
Proposal: add type checking for lock.updateTimeout

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,7 +86,7 @@ function updateLock(file, options) {
     const lock = locks[file];
 
     /* istanbul ignore next */
-    if (lock.updateTimeout != null) {
+    if (lock.updateTimeout) {
         return;
     }
 
@@ -135,7 +135,13 @@ threshold'), { code: 'ECOMPROMISED' }));
     // Unref the timer so that the nodejs process can exit freely
     // This is safe because all acquired locks will be automatically released
     // on process exit
-    if (lock.updateTimeout.unref) lock.updateTimeout.unref();
+
+    // We first check that `lock.updateTimeout.unref` exists because some users
+    // may be using this module outside of NodeJS (e.g., in an electron app), 
+    // and in those cases `setTimeout` return an integer.
+    if (lock.updateTimeout.unref) {
+        lock.updateTimeout.unref();
+    }
 }
 
 function compromisedLock(file, lock, err) {

--- a/index.js
+++ b/index.js
@@ -86,7 +86,7 @@ function updateLock(file, options) {
     const lock = locks[file];
 
     /* istanbul ignore next */
-    if (lock.updateTimeout) {
+    if (lock.updateTimeout != null) {
         return;
     }
 
@@ -135,7 +135,7 @@ threshold'), { code: 'ECOMPROMISED' }));
     // Unref the timer so that the nodejs process can exit freely
     // This is safe because all acquired locks will be automatically released
     // on process exit
-    lock.updateTimeout.unref();
+    if (lock.updateTimeout.unref) lock.updateTimeout.unref();
 }
 
 function compromisedLock(file, lock, err) {


### PR DESCRIPTION
The reason I'd like to add this is so that this module can be used inside of an `electron` application.
In an `electron` app's `renderer` process (similar context to the browser) `setTimeout` returns an integer, not an object like in node.

I'm just adding these checks so that this module will work in both `node` and `electron`.